### PR TITLE
feature: 난독증 교안 뷰어 블록 파서 적용

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,1 +1,2651 @@
-{"openapi":"3.1.0","info":{"title":"Dyslexia API","description":"API for Dyslexia application","version":"1.0.0"},"servers":[{"url":"http://localhost:8080/api","description":"Generated server url"}],"security":[{"bearerAuth":[]}],"tags":[{"name":"Student","description":"학생 관련 API"},{"name":"Teacher","description":"교사 관련 API"},{"name":"Kakao","description":"카카오 로그인 관련 API"},{"name":"TeacherDocument","description":"선생님 문서 관리 API"},{"name":"Document Content API","description":"PDF 문서 콘텐츠 관련 API"},{"name":"User","description":"사용자 관련 API"},{"name":"Document","description":"PDF 문서 관리 API"},{"name":"DocumentStatus","description":"문서 처리 상태 관리 API"},{"name":"StudentDocument","description":"학생 문서 관리 API"}],"paths":{"/users/signup":{"post":{"tags":["User"],"summary":"회원가입","description":"새로운 사용자를 등록합니다.","operationId":"signUp","requestBody":{"description":"회원가입 요청 정보","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SignUpRequestDto"}}},"required":true},"responses":{"200":{"description":"회원가입 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SignUpResponseDto"}}}}}}},"/teacher/documents/assign":{"post":{"tags":["TeacherDocument"],"summary":"학생에게 문서 할당","description":"선생님이 학생에게 문서를 할당합니다.","operationId":"assignDocumentToStudent","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentAssignmentRequest"}}},"required":true},"responses":{"200":{"description":"할당 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ResponseDto"}}}},"404":{"description":"선생님, 학생 또는 문서를 찾을 수 없음","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ResponseDto"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ResponseDto"}}}}}}},"/students/match/{id}":{"post":{"tags":["Student"],"summary":"매칭 코드로 교사 매칭","description":"매칭 코드를 사용하여 학생과 교사를 연결합니다.","operationId":"matchByCode","parameters":[{"name":"arg1","in":"query","description":"매칭 코드","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"매칭 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MatchResponseDto"}}}}}}},"/student/documents/{studentId}/page/{pageId}/progress":{"post":{"tags":["StudentDocument"],"summary":"페이지 진행 상태 업데이트","description":"학생의 페이지 학습 진행 상태를 업데이트합니다.","operationId":"updatePageProgress","parameters":[],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/PageProgressUpdateRequest"}}},"required":true},"responses":{"200":{"description":"업데이트 성공","content":{"application/json":{"schema":{"type":"object"}}}},"404":{"description":"페이지를 찾을 수 없음","content":{"application/json":{"schema":{"type":"object"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"type":"object"}}}}}}},"/student/documents/{studentId}/page/{pageId}/accessibility":{"post":{"tags":["StudentDocument"],"summary":"페이지 접근성 설정 업데이트","description":"학생의 페이지 접근성 설정을 업데이트합니다.","operationId":"updateAccessibilitySettings","parameters":[],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/AccessibilitySettingsUpdateRequest"}}},"required":true},"responses":{"200":{"description":"업데이트 성공","content":{"application/json":{"schema":{"type":"object"}}}},"404":{"description":"페이지를 찾을 수 없음","content":{"application/json":{"schema":{"type":"object"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"type":"object"}}}}}}},"/openai/generate-text":{"post":{"tags":["open-ai-controller"],"operationId":"generateText","requestBody":{"content":{"application/json":{"schema":{"type":"string"}}},"required":true},"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AIResponseDto"}}}}}}},"/ocr/upload":{"post":{"tags":["ocr-controller"],"operationId":"upload","requestBody":{"content":{"multipart/form-data":{"schema":{"type":"object","properties":{"file":{"type":"string","format":"binary"}},"required":["file"]}}}},"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{"type":"string"}}}}}}},"/documents/upload":{"post":{"tags":["Document"],"summary":"PDF 문서 업로드","description":"선생님이 PDF 문서를 업로드하고 처리를 시작합니다.","operationId":"uploadDocument","parameters":[{"name":"teacherId","in":"query","description":"선생님 ID","required":true,"schema":{"type":"integer","format":"int64"}},{"name":"title","in":"query","description":"문서 제목","required":true,"schema":{"type":"string"}},{"name":"grade","in":"query","description":"학년","required":true,"schema":{"type":"string","enum":["GRADE_1","GRADE_2","GRADE_3","GRADE_4","GRADE_5","GRADE_6"]}},{"name":"subjectPath","in":"query","description":"과목 경로","required":false,"schema":{"type":"string"}}],"requestBody":{"content":{"multipart/form-data":{"schema":{"type":"object","properties":{"file":{"type":"string","format":"binary","description":"PDF 파일"}},"required":["file"]}}}},"responses":{"200":{"description":"업로드 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentResponseDto"}}}},"400":{"description":"잘못된 요청","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentResponseDto"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentResponseDto"}}}}}}},"/documents/status/{documentId}/retry":{"post":{"tags":["DocumentStatus"],"summary":"문서 처리 재시도","description":"실패한 문서의 처리를 재시도합니다.","operationId":"retryDocumentProcessing","parameters":[{"name":"documentId","in":"path","description":"문서 ID","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"재시도 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentProcessStatusDto"}}}},"400":{"description":"재시도할 수 없는 상태","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentProcessStatusDto"}}}},"404":{"description":"문서를 찾을 수 없음","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentProcessStatusDto"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentProcessStatusDto"}}}}}}},"/courses":{"get":{"tags":["course-controller"],"operationId":"getCoursesByTeacher","parameters":[{"name":"arg0","in":"query","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/CourseDto"}}}}}}},"post":{"tags":["course-controller"],"operationId":"createCourse","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CourseReqDto"}}},"required":true},"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CourseDto"}}}}}}},"/courseInfo":{"get":{"tags":["course-info-controller"],"operationId":"getByStudent","parameters":[{"name":"arg0","in":"query","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/CourseInfoDto"}}}}}}},"post":{"tags":["course-info-controller"],"operationId":"createCourseInfo","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CourseInfoReqDto"}}},"required":true},"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CourseInfoDto"}}}}}}},"/users/me":{"get":{"tags":["User"],"summary":"내 정보 조회","description":"인증된 사용자의 정보를 조회합니다.","operationId":"getMyInfo","parameters":[{"name":"Authorization","in":"header","description":"JWT 토큰","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"내 정보 조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/UserInfoDto"}}}}}}},"/teachers":{"get":{"tags":["Teacher"],"summary":"client id로 교사 조회","description":"클라이언트 ID를 통해 교사 정보를 조회합니다.","operationId":"getByClientId","parameters":[{"name":"arg0","in":"query","description":"클라이언트 ID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TeacherDto"}}}}}}},"/teachers/{teacherId}/students":{"get":{"tags":["Teacher"],"summary":"id로 담당 학생 조회","description":"교사 ID를 통해 담당 학생 목록을 조회합니다.","operationId":"getStudentsByTeacherId","parameters":[],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDto"}}}}}}},"/teachers/{id}":{"get":{"tags":["Teacher"],"summary":"id로 교사 조회","description":"교사 ID를 통해 교사 정보를 조회합니다.","operationId":"getById","parameters":[],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TeacherDto"}}}}}}},"/teachers/code/{id}":{"get":{"tags":["Teacher"],"summary":"id로 매칭 코드 조회","description":"교사 ID를 통해 매칭 코드를 조회합니다.","operationId":"getCodeById","parameters":[],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TeacherCodeDto"}}}}}}},"/teacher/documents/{teacherId}":{"get":{"tags":["TeacherDocument"],"summary":"선생님이 업로드한 문서 목록 조회","description":"선생님이 업로드한 모든 문서 목록을 조회합니다.","operationId":"getTeacherDocuments","parameters":[{"name":"teacherId","in":"path","description":"선생님 ID","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDocumentListResponseDto"}}}},"404":{"description":"선생님을 찾을 수 없음","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDocumentListResponseDto"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDocumentListResponseDto"}}}}}}},"/teacher/documents/{teacherId}/student/{studentId}":{"get":{"tags":["TeacherDocument"],"summary":"선생님의 학생별 할당 문서 목록 조회","description":"선생님이 특정 학생에게 할당한 문서 목록을 조회합니다.","operationId":"getAssignedDocumentsForStudent","parameters":[],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDocumentListResponseDto"}}}},"404":{"description":"선생님 또는 학생을 찾을 수 없음","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDocumentListResponseDto"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDocumentListResponseDto"}}}}}}},"/students":{"get":{"tags":["Student"],"summary":"client id로 학생 조회","description":"클라이언트 ID를 통해 학생 정보를 조회합니다.","operationId":"getByClientId_1","parameters":[{"name":"arg0","in":"query","description":"클라이언트 ID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDto"}}}}}}},"/students/{id}":{"get":{"tags":["Student"],"summary":"id로 학생 조회","description":"학생 ID를 통해 학생 정보를 조회합니다.","operationId":"getById_1","parameters":[],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDto"}}}}}}},"/student/documents/{studentId}":{"get":{"tags":["StudentDocument"],"summary":"학생에게 할당된 문서 목록 조회","description":"학생에게 할당된 모든 문서 목록을 조회합니다.","operationId":"getAssignedDocuments","parameters":[],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDocumentListResponseDto"}}}},"404":{"description":"학생을 찾을 수 없음","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDocumentListResponseDto"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StudentDocumentListResponseDto"}}}}}}},"/student/documents/{studentId}/page/{pageId}":{"get":{"tags":["StudentDocument"],"summary":"페이지 상세 조회","description":"특정 페이지의 상세 내용과 팁, 이미지를 조회합니다.","operationId":"getPageDetail","parameters":[],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"type":"object"}}}},"404":{"description":"페이지를 찾을 수 없음","content":{"application/json":{"schema":{"type":"object"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"type":"object"}}}}}}},"/student/documents/{studentId}/document/{documentId}/pages":{"get":{"tags":["StudentDocument"],"summary":"문서 페이지 목록 조회","description":"특정 문서의 모든 페이지 정보를 조회합니다.","operationId":"getDocumentPages","parameters":[],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PageListResponseDto"}}}},"404":{"description":"문서를 찾을 수 없음","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PageListResponseDto"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PageListResponseDto"}}}}}}},"/kakao/callback":{"get":{"tags":["Kakao"],"summary":"카카오 로그인 콜백","description":"카카오 로그인 후 리다이렉트되는 콜백 URL입니다.","operationId":"kakaoCallback","parameters":[{"name":"code","in":"query","description":"카카오 인가 코드","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"로그인 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AuthResponseDto","description":"로그인 응답 데이터\n- registered: 회원가입 여부\n- clientId: 카카오 ID\n- nickname: 카카오 닉네임\n- userType: 사용자 타입 (STUDENT/TEACHER/UNREGISTERED)\n- accessToken: JWT 액세스 토큰 (회원가입된 경우에만)\n- refreshToken: JWT 리프레시 토큰 (회원가입된 경우에만)\n"}}}}}}},"/documents/status/{documentId}":{"get":{"tags":["DocumentStatus"],"summary":"문서 처리 상태 조회","description":"문서의 처리 상태와 진행도를 조회합니다.","operationId":"getDocumentStatus","parameters":[{"name":"documentId","in":"path","description":"문서 ID","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentProcessStatusDto"}}}},"404":{"description":"문서를 찾을 수 없음","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentProcessStatusDto"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentProcessStatusDto"}}}}}}},"/courses/{id}":{"get":{"tags":["course-controller"],"operationId":"getById_2","parameters":[],"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CourseDto"}}}}}}},"/courseInfo/{id}":{"get":{"tags":["course-info-controller"],"operationId":"getById_3","parameters":[],"responses":{"200":{"description":"OK","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CourseInfoDto"}}}}}}},"/api/document-contents/pages":{"get":{"tags":["Document Content API"],"summary":"문서 페이지 조회","description":"문서 ID 기반으로 생성된 콘텐츠 JSON(page)를 조회합니다. 페이지 번호를 지정하면 특정 페이지만 조회합니다.","operationId":"getDocumentPages_1","parameters":[{"name":"documentId","in":"query","description":"문서 ID","required":true,"schema":{"type":"integer","format":"int64"}},{"name":"page","in":"query","description":"페이지 번호 (선택사항)","required":false,"schema":{"type":"integer","format":"int32"}}],"responses":{"200":{"description":"페이지 목록 조회 성공","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/PageContentResponse"}}}}}}}},"/api/document-contents/pages/{pageId}/tips":{"get":{"tags":["Document Content API"],"summary":"페이지 팁 조회","description":"페이지 ID 기반으로 해당 페이지의 팁을 조회합니다.","operationId":"getPageTips","parameters":[{"name":"pageId","in":"path","description":"페이지 ID","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"페이지 팁 목록 조회 성공","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/PageTipResponse"}}}}}}}},"/api/document-contents/pages/{pageId}/images":{"get":{"tags":["Document Content API"],"summary":"페이지 이미지 조회","description":"페이지 ID 기반으로 해당 페이지의 이미지를 조회합니다.","operationId":"getPageImages","parameters":[{"name":"pageId","in":"path","description":"페이지 ID","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"페이지 이미지 목록 조회 성공","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/PageImageResponse"}}}}}}}},"/teacher/documents/assign/{teacherId}/{studentId}/{documentId}":{"delete":{"tags":["TeacherDocument"],"summary":"학생 문서 할당 취소","description":"선생님이 학생에게 할당한 문서를 취소합니다.","operationId":"unassignDocumentFromStudent","parameters":[],"responses":{"200":{"description":"취소 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ResponseDto"}}}},"404":{"description":"할당 정보를 찾을 수 없음","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ResponseDto"}}}},"500":{"description":"서버 오류","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ResponseDto"}}}}}}}},"components":{"schemas":{"SignUpRequestDto":{"type":"object","properties":{"clientId":{"type":"string"},"name":{"type":"string"},"userType":{"type":"string","enum":["STUDENT","TEACHER","UNREGISTERED"]},"grade":{"type":"string","enum":["GRADE_1","GRADE_2","GRADE_3","GRADE_4","GRADE_5","GRADE_6"]},"type":{"type":"string"},"interestIds":{"type":"array","items":{"type":"integer","format":"int64"}},"organization":{"type":"string"}}},"SignUpResponseDto":{"type":"object","properties":{"id":{"type":"integer","format":"int64"},"name":{"type":"string"},"userType":{"type":"string","enum":["STUDENT","TEACHER","UNREGISTERED"]},"accessToken":{"type":"string"},"refreshToken":{"type":"string"}}},"DocumentAssignmentRequest":{"type":"object","description":"문서 할당 요청 DTO","properties":{"teacherId":{"type":"integer","format":"int64","description":"선생님 ID","example":1},"studentId":{"type":"integer","format":"int64","description":"학생 ID","example":1},"documentId":{"type":"integer","format":"int64","description":"문서 ID","example":1},"dueDate":{"type":"string","format":"date-time","description":"제출 기한","example":"2023-12-31T23:59:59"},"notes":{"type":"string","description":"메모","example":"이 문서를 다음 주까지 완료해 주세요."}},"required":["documentId","studentId","teacherId"]},"ResponseDto":{"type":"object","description":"일반 응답 DTO","properties":{"success":{"type":"boolean","description":"처리 성공 여부","example":true},"message":{"type":"string","description":"응답 메시지","example":"처리가 완료되었습니다."},"data":{"type":"object","description":"데이터"}}},"MatchResponseDto":{"type":"object","properties":{"id":{"type":"integer","format":"int64"},"organization":{"type":"string"},"profileImageUrl":{"type":"string"},"matchCode":{"type":"string"}}},"PageProgressUpdateRequest":{"type":"object","description":"페이지 진행 상태 업데이트 요청 DTO","properties":{"pageId":{"type":"integer","format":"int64","description":"페이지 ID","example":1},"studentId":{"type":"integer","format":"int64","description":"학생 ID","example":1},"timeSpentSeconds":{"type":"integer","format":"int32","description":"진행 시간(초)","example":300},"completionStatus":{"type":"string","description":"완료 상태","enum":["NOT_STARTED","IN_PROGRESS","COMPLETED"],"example":"COMPLETED"},"retryCount":{"type":"integer","format":"int32","description":"재시도 횟수","example":2},"usedTipIds":{"type":"array","description":"사용된 팁 ID 목록","example":[1,2,3],"items":{"type":"integer","format":"int64"}},"comprehensionScore":{"type":"integer","format":"int32","description":"이해도 점수 (0-100)","example":85},"notes":{"type":"string","description":"메모","example":"어려운 개념들이 많아서 시간이 오래 걸렸습니다."}}},"AccessibilitySettingsUpdateRequest":{"type":"object","description":"접근성 설정 업데이트 요청 DTO","properties":{"pageId":{"type":"integer","format":"int64","description":"페이지 ID","example":1},"studentId":{"type":"integer","format":"int64","description":"학생 ID","example":1},"documentId":{"type":"integer","format":"int64","description":"문서 ID","example":1},"fontSize":{"type":"integer","format":"int32","description":"글꼴 크기","example":18},"lineSpacing":{"type":"number","format":"float","description":"줄 간격","example":1.5},"letterSpacing":{"type":"number","format":"float","description":"글자 간격","example":1.2},"colorScheme":{"type":"string","description":"색상 스키마","enum":["LIGHT","DARK","SEPIA","CUSTOM"],"example":"DARK_MODE"},"textToSpeechEnabled":{"type":"boolean","description":"자동 음성 읽기 활성화","example":true},"readingHighlightEnabled":{"type":"boolean","description":"읽기 강조 표시 활성화","example":true},"saveAsDefault":{"type":"boolean","description":"기본 설정으로 저장","example":false},"applyToEntireDocument":{"type":"boolean","description":"문서 전체에 적용","example":true},"customBackgroundColor":{"type":"string","description":"사용자 정의 배경색","example":"#F5F5DC"},"customTextColor":{"type":"string","description":"사용자 정의 글자색","example":"#333333"}}},"AIResponseDto":{"type":"object","properties":{"output":{"type":"string"},"message":{"type":"string"},"status":{"type":"string"}}},"DocumentDto":{"type":"object","description":"문서 정보 DTO","properties":{"id":{"type":"integer","format":"int64","description":"문서 ID","example":1},"teacherId":{"type":"integer","format":"int64","description":"선생님 ID","example":1},"title":{"type":"string","description":"문서 제목","example":"생태계와 환경"},"originalFilename":{"type":"string","description":"원본 파일명","example":"ecology_and_environment.pdf"},"fileSize":{"type":"integer","format":"int64","description":"파일 크기(바이트)","example":1024000},"pageCount":{"type":"integer","format":"int32","description":"페이지 수","example":10},"grade":{"type":"string","description":"학년","enum":["GRADE_1","GRADE_2","GRADE_3","GRADE_4","GRADE_5","GRADE_6"],"example":"GRADE_3"},"subjectPath":{"type":"string","description":"과목 경로","example":"science/ecology"},"processStatus":{"type":"string","description":"처리 상태","enum":["PENDING","PROCESSING","COMPLETED","FAILED"],"example":"COMPLETED"},"createdAt":{"type":"string","format":"date-time","description":"생성 시간"},"updatedAt":{"type":"string","format":"date-time","description":"수정 시간"}}},"DocumentResponseDto":{"type":"object","description":"문서 업로드 응답 DTO","properties":{"success":{"type":"boolean","description":"처리 성공 여부","example":true},"message":{"type":"string","description":"응답 메시지","example":"PDF 업로드 완료. 비동기 처리가 시작되었습니다."},"document":{"$ref":"#/components/schemas/DocumentDto","description":"문서 정보"}}},"DocumentProcessStatusDto":{"type":"object","description":"문서 처리 상태 응답 DTO","properties":{"success":{"type":"boolean","description":"처리 성공 여부","example":true},"message":{"type":"string","description":"응답 메시지","example":"문서 처리 상태 조회 성공"},"documentId":{"type":"integer","format":"int64","description":"문서 ID","example":1},"status":{"type":"string","description":"처리 상태","enum":["PENDING","PROCESSING","COMPLETED","FAILED"],"example":"PROCESSING"},"progress":{"type":"integer","format":"int32","description":"처리 진행도 (0-100)","example":65}}},"CourseReqDto":{"type":"object","properties":{"teacherId":{"type":"integer","format":"int64"},"subjectPath":{"type":"string"},"title":{"type":"string"},"type":{"type":"string"},"grade":{"type":"string","enum":["GRADE_1","GRADE_2","GRADE_3","GRADE_4","GRADE_5","GRADE_6"]},"state":{"type":"string"}}},"CourseDto":{"type":"object","properties":{"id":{"type":"integer","format":"int64"},"teacherId":{"type":"integer","format":"int64"},"subjectPath":{"type":"string"},"title":{"type":"string"},"type":{"type":"string"},"grade":{"type":"string","enum":["GRADE_1","GRADE_2","GRADE_3","GRADE_4","GRADE_5","GRADE_6"]},"createdAt":{"type":"string","format":"date-time"},"updatedAt":{"type":"string","format":"date-time"},"state":{"type":"string"}}},"CourseInfoReqDto":{"type":"object","properties":{"courseId":{"type":"integer","format":"int64"},"studentId":{"type":"integer","format":"int64"},"teacherId":{"type":"integer","format":"int64"},"learningTime":{"type":"integer","format":"int32"},"page":{"type":"integer","format":"int32"},"maxPage":{"type":"integer","format":"int32"}}},"CourseInfoDto":{"type":"object","properties":{"id":{"type":"integer","format":"int64"},"courseId":{"type":"integer","format":"int64"},"studentId":{"type":"integer","format":"int64"},"teacherId":{"type":"integer","format":"int64"},"learningTime":{"type":"integer","format":"int32"},"page":{"type":"integer","format":"int32"},"maxPage":{"type":"integer","format":"int32"}}},"UserInfoDto":{"type":"object","description":"사용자 정보 응답 DTO","properties":{"name":{"type":"string","description":"사용자 닉네임","example":"홍길동"},"id":{"type":"integer","format":"int64","description":"사용자 ID","example":1},"clientId":{"type":"string","description":"카카오 ID","example":123456789},"userType":{"type":"string","description":"사용자 타입","enum":["STUDENT","TEACHER","UNREGISTERED"],"example":"STUDENT"}}},"TeacherDto":{"type":"object","properties":{"id":{"type":"integer","format":"int64"},"clientId":{"type":"string"},"name":{"type":"string"},"organization":{"type":"string"},"profileImageUrl":{"type":"string"}}},"StudentDto":{"type":"object","properties":{"id":{"type":"integer","format":"int64"},"clientId":{"type":"string"},"teacherId":{"type":"integer","format":"int64"},"grade":{"type":"string","enum":["GRADE_1","GRADE_2","GRADE_3","GRADE_4","GRADE_5","GRADE_6"]},"type":{"type":"string"},"state":{"type":"boolean"},"profileImageUrl":{"type":"string"},"interests":{"type":"array","items":{"type":"string"}}}},"TeacherCodeDto":{"type":"object","properties":{"matchCode":{"type":"string"}}},"StudentDocumentListResponseDto":{"type":"object","description":"학생 문서 목록 응답 DTO","properties":{"success":{"type":"boolean","description":"처리 성공 여부","example":true},"message":{"type":"string","description":"응답 메시지","example":"할당된 문서 목록 조회 성공"},"documents":{"type":"array","description":"문서 목록","items":{"$ref":"#/components/schemas/DocumentDto"}}}},"PageDto":{"type":"object","description":"페이지 정보 DTO","properties":{"id":{"type":"integer","format":"int64","description":"페이지 ID","example":1},"documentId":{"type":"integer","format":"int64","description":"문서 ID","example":1},"pageNumber":{"type":"integer","format":"int32","description":"페이지 번호","example":1},"sectionTitle":{"type":"string","description":"섹션 제목","example":"생태계의 구성 요소"},"readingLevel":{"type":"integer","format":"int32","description":"읽기 난이도 (1-10)","example":5},"wordCount":{"type":"integer","format":"int32","description":"단어 수","example":250},"complexityScore":{"type":"number","format":"float","description":"복잡도 점수 (0.0-1.0)","example":0.6},"processingStatus":{"type":"string","description":"처리 상태","enum":["PENDING","PROCESSING","COMPLETED","FAILED"],"example":"COMPLETED"},"createdAt":{"type":"string","format":"date-time","description":"생성 시간"},"updatedAt":{"type":"string","format":"date-time","description":"수정 시간"}}},"PageListResponseDto":{"type":"object","description":"페이지 목록 응답 DTO","properties":{"success":{"type":"boolean","description":"처리 성공 여부","example":true},"message":{"type":"string","description":"응답 메시지","example":"페이지 목록 조회 성공"},"pages":{"type":"array","description":"페이지 목록","items":{"$ref":"#/components/schemas/PageDto"}}}},"AuthResponseDto":{"type":"object","properties":{"registered":{"type":"boolean"},"clientId":{"type":"string"},"nickname":{"type":"string"},"userType":{"type":"string"},"accessToken":{"type":"string"},"refreshToken":{"type":"string"}}},"JsonNode":{"type":"object"},"PageContentResponse":{"type":"object","description":"페이지 콘텐츠 응답","properties":{"id":{"type":"integer","format":"int64","description":"페이지 ID"},"documentId":{"type":"integer","format":"int64","description":"문서 ID"},"pageNumber":{"type":"integer","format":"int32","description":"페이지 번호"},"originalContent":{"type":"string","description":"원본 콘텐츠"},"processedContent":{"$ref":"#/components/schemas/JsonNode","description":"처리된 콘텐츠 (JSON)"},"processingStatus":{"type":"string","description":"처리 상태","enum":["PENDING","PROCESSING","COMPLETED","FAILED"],"example":"COMPLETED"},"sectionTitle":{"type":"string","description":"섹션 제목"},"readingLevel":{"type":"integer","format":"int32","description":"읽기 레벨"},"wordCount":{"type":"integer","format":"int32","description":"단어 수"},"complexityScore":{"type":"number","format":"float","description":"복잡도 점수"},"createdAt":{"type":"string","format":"date-time","description":"생성 시간"},"updatedAt":{"type":"string","format":"date-time","description":"수정 시간"}}},"PageTipResponse":{"type":"object","description":"페이지 팁 응답","properties":{"id":{"type":"integer","format":"int64","description":"팁 ID"},"pageId":{"type":"integer","format":"int64","description":"페이지 ID"},"term":{"type":"string","description":"용어"},"simplifiedExplanation":{"type":"string","description":"간소화된 설명"},"termPosition":{"$ref":"#/components/schemas/JsonNode","description":"용어 위치 정보 (JSON)"},"termType":{"type":"string","description":"용어 타입","enum":["DIFFICULT_WORD","COMPLEX_CONCEPT","ABSTRACT_IDEA","TECHNICAL_TERM"],"example":"VOCABULARY"},"visualAidNeeded":{"type":"boolean","description":"시각적 보조 필요 여부"},"readAloudText":{"type":"string","description":"읽기 텍스트"},"createdAt":{"type":"string","format":"date-time","description":"생성 시간"},"updatedAt":{"type":"string","format":"date-time","description":"수정 시간"}}},"PageImageResponse":{"type":"object","description":"페이지 이미지 응답","properties":{"id":{"type":"integer","format":"int64","description":"이미지 ID"},"pageId":{"type":"integer","format":"int64","description":"페이지 ID"},"imageUrl":{"type":"string","description":"이미지 URL"},"imageType":{"type":"string","description":"이미지 타입","enum":["CONCEPT_VISUALIZATION","DIAGRAM","COMPARISON_CHART","EXAMPLE_ILLUSTRATION"],"example":"DIAGRAM"},"conceptReference":{"type":"string","description":"개념 참조"},"altText":{"type":"string","description":"대체 텍스트"},"positionInPage":{"$ref":"#/components/schemas/JsonNode","description":"페이지 내 위치 정보 (JSON)"},"createdAt":{"type":"string","format":"date-time","description":"생성 시간"},"updatedAt":{"type":"string","format":"date-time","description":"수정 시간"}}}},"securitySchemes":{"bearerAuth":{"type":"http","scheme":"bearer","bearerFormat":"JWT"}}}}
+// 20250511163506
+// http://localhost:8080/api/v3/api-docs
+
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Dyslexia API",
+    "description": "API for Dyslexia application",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080/api",
+      "description": "Generated server url"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": [
+        
+      ]
+    }
+  ],
+  "tags": [
+    {
+      "name": "Student",
+      "description": "학생 관련 API"
+    },
+    {
+      "name": "Teacher",
+      "description": "교사 관련 API"
+    },
+    {
+      "name": "Kakao",
+      "description": "카카오 로그인 관련 API"
+    },
+    {
+      "name": "TeacherDocument",
+      "description": "선생님 문서 관리 API"
+    },
+    {
+      "name": "Document Content API",
+      "description": "PDF 문서 콘텐츠 관련 API"
+    },
+    {
+      "name": "User",
+      "description": "사용자 관련 API"
+    },
+    {
+      "name": "Document",
+      "description": "PDF 문서 관리 API"
+    },
+    {
+      "name": "DocumentStatus",
+      "description": "문서 처리 상태 관리 API"
+    },
+    {
+      "name": "StudentDocument",
+      "description": "학생 문서 관리 API"
+    }
+  ],
+  "paths": {
+    "/users/signup": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "summary": "회원가입",
+        "description": "새로운 사용자를 등록합니다.",
+        "operationId": "signUp",
+        "requestBody": {
+          "description": "회원가입 요청 정보",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignUpRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "회원가입 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignUpResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teacher/documents/assign": {
+      "post": {
+        "tags": [
+          "TeacherDocument"
+        ],
+        "summary": "학생에게 문서 할당",
+        "description": "선생님이 학생에게 문서를 할당합니다.",
+        "operationId": "assignDocumentToStudent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentAssignmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "할당 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "선생님, 학생 또는 문서를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/students/match/{id}": {
+      "post": {
+        "tags": [
+          "Student"
+        ],
+        "summary": "매칭 코드로 교사 매칭",
+        "description": "매칭 코드를 사용하여 학생과 교사를 연결합니다.",
+        "operationId": "matchByCode",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "학생 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "code",
+            "in": "query",
+            "description": "매칭 코드",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "매칭 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/student/documents/{studentId}/page/{pageId}/progress": {
+      "post": {
+        "tags": [
+          "StudentDocument"
+        ],
+        "summary": "페이지 진행 상태 업데이트",
+        "description": "학생의 페이지 학습 진행 상태를 업데이트합니다.",
+        "operationId": "updatePageProgress",
+        "parameters": [
+          {
+            "name": "studentId",
+            "in": "path",
+            "description": "학생 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "pageId",
+            "in": "path",
+            "description": "페이지 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PageProgressUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "업데이트 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "페이지를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/student/documents/{studentId}/page/{pageId}/accessibility": {
+      "post": {
+        "tags": [
+          "StudentDocument"
+        ],
+        "summary": "페이지 접근성 설정 업데이트",
+        "description": "학생의 페이지 접근성 설정을 업데이트합니다.",
+        "operationId": "updateAccessibilitySettings",
+        "parameters": [
+          {
+            "name": "studentId",
+            "in": "path",
+            "description": "학생 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "pageId",
+            "in": "path",
+            "description": "페이지 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccessibilitySettingsUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "업데이트 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "페이지를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openai/generate-text": {
+      "post": {
+        "tags": [
+          "open-ai-controller"
+        ],
+        "operationId": "generateText",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ocr/upload": {
+      "post": {
+        "tags": [
+          "ocr-controller"
+        ],
+        "operationId": "upload",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/upload": {
+      "post": {
+        "tags": [
+          "Document"
+        ],
+        "summary": "PDF 문서 업로드",
+        "description": "선생님이 PDF 문서를 업로드하고 처리를 시작합니다.",
+        "operationId": "uploadDocument",
+        "parameters": [
+          {
+            "name": "teacherId",
+            "in": "query",
+            "description": "선생님 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "title",
+            "in": "query",
+            "description": "문서 제목",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "grade",
+            "in": "query",
+            "description": "학년",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "GRADE_1",
+                "GRADE_2",
+                "GRADE_3",
+                "GRADE_4",
+                "GRADE_5",
+                "GRADE_6"
+              ]
+            }
+          },
+          {
+            "name": "subjectPath",
+            "in": "query",
+            "description": "과목 경로",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "PDF 파일"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "업로드 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "잘못된 요청",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponseDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/status/{documentId}/retry": {
+      "post": {
+        "tags": [
+          "DocumentStatus"
+        ],
+        "summary": "문서 처리 재시도",
+        "description": "실패한 문서의 처리를 재시도합니다.",
+        "operationId": "retryDocumentProcessing",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "문서 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "재시도 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentProcessStatusDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "재시도할 수 없는 상태",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentProcessStatusDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "문서를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentProcessStatusDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentProcessStatusDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/courses": {
+      "get": {
+        "tags": [
+          "course-controller"
+        ],
+        "operationId": "getCoursesByTeacher",
+        "parameters": [
+          {
+            "name": "teacherId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CourseDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "course-controller"
+        ],
+        "operationId": "createCourse",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CourseReqDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/courseInfo": {
+      "get": {
+        "tags": [
+          "course-info-controller"
+        ],
+        "operationId": "getByStudent",
+        "parameters": [
+          {
+            "name": "studentId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CourseInfoDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "course-info-controller"
+        ],
+        "operationId": "createCourseInfo",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CourseInfoReqDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseInfoDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/me": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "summary": "내 정보 조회",
+        "description": "인증된 사용자의 정보를 조회합니다.",
+        "operationId": "getMyInfo",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "JWT 토큰",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "내 정보 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserInfoDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teachers": {
+      "get": {
+        "tags": [
+          "Teacher"
+        ],
+        "summary": "client id로 교사 조회",
+        "description": "클라이언트 ID를 통해 교사 정보를 조회합니다.",
+        "operationId": "getByClientId",
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "query",
+            "description": "클라이언트 ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeacherDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teachers/{teacherId}/students": {
+      "get": {
+        "tags": [
+          "Teacher"
+        ],
+        "summary": "id로 담당 학생 조회",
+        "description": "교사 ID를 통해 담당 학생 목록을 조회합니다.",
+        "operationId": "getStudentsByTeacherId",
+        "parameters": [
+          {
+            "name": "teacherId",
+            "in": "path",
+            "description": "교사 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teachers/{id}": {
+      "get": {
+        "tags": [
+          "Teacher"
+        ],
+        "summary": "id로 교사 조회",
+        "description": "교사 ID를 통해 교사 정보를 조회합니다.",
+        "operationId": "getById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "교사 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeacherDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teachers/code/{id}": {
+      "get": {
+        "tags": [
+          "Teacher"
+        ],
+        "summary": "id로 매칭 코드 조회",
+        "description": "교사 ID를 통해 매칭 코드를 조회합니다.",
+        "operationId": "getCodeById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "교사 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeacherCodeDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teacher/documents/{teacherId}": {
+      "get": {
+        "tags": [
+          "TeacherDocument"
+        ],
+        "summary": "선생님이 업로드한 문서 목록 조회",
+        "description": "선생님이 업로드한 모든 문서 목록을 조회합니다.",
+        "operationId": "getTeacherDocuments",
+        "parameters": [
+          {
+            "name": "teacherId",
+            "in": "path",
+            "description": "선생님 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDocumentListResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "선생님을 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDocumentListResponseDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDocumentListResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teacher/documents/{teacherId}/student/{studentId}": {
+      "get": {
+        "tags": [
+          "TeacherDocument"
+        ],
+        "summary": "선생님의 학생별 할당 문서 목록 조회",
+        "description": "선생님이 특정 학생에게 할당한 문서 목록을 조회합니다.",
+        "operationId": "getAssignedDocumentsForStudent",
+        "parameters": [
+          {
+            "name": "teacherId",
+            "in": "path",
+            "description": "선생님 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "studentId",
+            "in": "path",
+            "description": "학생 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDocumentListResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "선생님 또는 학생을 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDocumentListResponseDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDocumentListResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/students": {
+      "get": {
+        "tags": [
+          "Student"
+        ],
+        "summary": "client id로 학생 조회",
+        "description": "클라이언트 ID를 통해 학생 정보를 조회합니다.",
+        "operationId": "getByClientId_1",
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "query",
+            "description": "클라이언트 ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/students/{id}": {
+      "get": {
+        "tags": [
+          "Student"
+        ],
+        "summary": "id로 학생 조회",
+        "description": "학생 ID를 통해 학생 정보를 조회합니다.",
+        "operationId": "getById_1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "학생 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/student/documents/{studentId}": {
+      "get": {
+        "tags": [
+          "StudentDocument"
+        ],
+        "summary": "학생에게 할당된 문서 목록 조회",
+        "description": "학생에게 할당된 모든 문서 목록을 조회합니다.",
+        "operationId": "getAssignedDocuments",
+        "parameters": [
+          {
+            "name": "studentId",
+            "in": "path",
+            "description": "학생 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDocumentListResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "학생을 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDocumentListResponseDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StudentDocumentListResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/student/documents/{studentId}/page/{pageId}": {
+      "get": {
+        "tags": [
+          "StudentDocument"
+        ],
+        "summary": "페이지 상세 조회",
+        "description": "특정 페이지의 상세 내용과 팁, 이미지를 조회합니다.",
+        "operationId": "getPageDetail",
+        "parameters": [
+          {
+            "name": "studentId",
+            "in": "path",
+            "description": "학생 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "pageId",
+            "in": "path",
+            "description": "페이지 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "페이지를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/student/documents/{studentId}/document/{documentId}/pages": {
+      "get": {
+        "tags": [
+          "StudentDocument"
+        ],
+        "summary": "문서 페이지 목록 조회",
+        "description": "특정 문서의 모든 페이지 정보를 조회합니다.",
+        "operationId": "getDocumentPages",
+        "parameters": [
+          {
+            "name": "studentId",
+            "in": "path",
+            "description": "학생 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "문서 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageListResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "문서를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageListResponseDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageListResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/kakao/callback": {
+      "get": {
+        "tags": [
+          "Kakao"
+        ],
+        "summary": "카카오 로그인 콜백",
+        "description": "카카오 로그인 후 리다이렉트되는 콜백 URL입니다.",
+        "operationId": "kakaoCallback",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "description": "카카오 인가 코드",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "로그인 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponseDto",
+                  "description": "로그인 응답 데이터\n- registered: 회원가입 여부\n- clientId: 카카오 ID\n- nickname: 카카오 닉네임\n- userType: 사용자 타입 (STUDENT/TEACHER/UNREGISTERED)\n- accessToken: JWT 액세스 토큰 (회원가입된 경우에만)\n- refreshToken: JWT 리프레시 토큰 (회원가입된 경우에만)\n"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/status/{documentId}": {
+      "get": {
+        "tags": [
+          "DocumentStatus"
+        ],
+        "summary": "문서 처리 상태 조회",
+        "description": "문서의 처리 상태와 진행도를 조회합니다.",
+        "operationId": "getDocumentStatus",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "문서 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentProcessStatusDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "문서를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentProcessStatusDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentProcessStatusDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/document-contents/pages": {
+      "get": {
+        "tags": [
+          "Document Content API"
+        ],
+        "summary": "문서 페이지 조회",
+        "description": "문서 ID 기반으로 생성된 콘텐츠 JSON(page)를 조회합니다. 페이지 번호를 지정하면 특정 페이지만 조회합니다.\n\nBlock 구조 예시:\n[\n  {\"id\":\"1\",\"type\":\"HEADING1\",\"text\":\"챕터 제목\"},\n  {\"id\":\"2\",\"type\":\"TEXT\",\"text\":\"본문\"},\n  {\"id\":\"3\",\"type\":\"LIST\",\"items\":[\"항목1\",\"항목2\"]}\n]",
+        "operationId": "getDocumentPages_1",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "query",
+            "description": "문서 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "페이지 번호 (선택사항)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "페이지 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PageContentResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/document-contents/pages/{pageId}/tips": {
+      "get": {
+        "tags": [
+          "Document Content API"
+        ],
+        "summary": "페이지 팁 조회",
+        "description": "페이지 ID 기반으로 해당 페이지의 팁을 조회합니다.",
+        "operationId": "getPageTips",
+        "parameters": [
+          {
+            "name": "pageId",
+            "in": "path",
+            "description": "페이지 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "페이지 팁 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PageTipResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/document-contents/pages/{pageId}/images": {
+      "get": {
+        "tags": [
+          "Document Content API"
+        ],
+        "summary": "페이지 이미지 조회",
+        "description": "페이지 ID 기반으로 해당 페이지의 이미지를 조회합니다.",
+        "operationId": "getPageImages",
+        "parameters": [
+          {
+            "name": "pageId",
+            "in": "path",
+            "description": "페이지 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "페이지 이미지 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PageImageResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/courses/{id}": {
+      "get": {
+        "tags": [
+          "course-controller"
+        ],
+        "operationId": "getById_2",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/courseInfo/{id}": {
+      "get": {
+        "tags": [
+          "course-info-controller"
+        ],
+        "operationId": "getById_3",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseInfoDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teacher/documents/assign/{teacherId}/{studentId}/{documentId}": {
+      "delete": {
+        "tags": [
+          "TeacherDocument"
+        ],
+        "summary": "학생 문서 할당 취소",
+        "description": "선생님이 학생에게 할당한 문서를 취소합니다.",
+        "operationId": "unassignDocumentFromStudent",
+        "parameters": [
+          {
+            "name": "teacherId",
+            "in": "path",
+            "description": "선생님 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "studentId",
+            "in": "path",
+            "description": "학생 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "문서 ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "취소 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "할당 정보를 찾을 수 없음",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SignUpRequestDto": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "userType": {
+            "type": "string",
+            "enum": [
+              "STUDENT",
+              "TEACHER",
+              "UNREGISTERED"
+            ]
+          },
+          "grade": {
+            "type": "string",
+            "enum": [
+              "GRADE_1",
+              "GRADE_2",
+              "GRADE_3",
+              "GRADE_4",
+              "GRADE_5",
+              "GRADE_6"
+            ]
+          },
+          "type": {
+            "type": "string"
+          },
+          "interestIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "organization": {
+            "type": "string"
+          }
+        }
+      },
+      "SignUpResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "userType": {
+            "type": "string",
+            "enum": [
+              "STUDENT",
+              "TEACHER",
+              "UNREGISTERED"
+            ]
+          },
+          "accessToken": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          }
+        }
+      },
+      "DocumentAssignmentRequest": {
+        "type": "object",
+        "description": "문서 할당 요청 DTO",
+        "properties": {
+          "teacherId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "선생님 ID",
+            "example": 1
+          },
+          "studentId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "학생 ID",
+            "example": 1
+          },
+          "documentId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "문서 ID",
+            "example": 1
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "제출 기한",
+            "example": "2023-12-31T23:59:59"
+          },
+          "notes": {
+            "type": "string",
+            "description": "메모",
+            "example": "이 문서를 다음 주까지 완료해 주세요."
+          }
+        },
+        "required": [
+          "documentId",
+          "studentId",
+          "teacherId"
+        ]
+      },
+      "ResponseDto": {
+        "type": "object",
+        "description": "일반 응답 DTO",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "처리 성공 여부",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "응답 메시지",
+            "example": "처리가 완료되었습니다."
+          },
+          "data": {
+            "type": "object",
+            "description": "데이터"
+          }
+        }
+      },
+      "MatchResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "profileImageUrl": {
+            "type": "string"
+          },
+          "matchCode": {
+            "type": "string"
+          }
+        }
+      },
+      "PageProgressUpdateRequest": {
+        "type": "object",
+        "description": "페이지 진행 상태 업데이트 요청 DTO",
+        "properties": {
+          "pageId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "페이지 ID",
+            "example": 1
+          },
+          "studentId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "학생 ID",
+            "example": 1
+          },
+          "timeSpentSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "description": "진행 시간(초)",
+            "example": 300
+          },
+          "completionStatus": {
+            "type": "string",
+            "description": "완료 상태",
+            "enum": [
+              "NOT_STARTED",
+              "IN_PROGRESS",
+              "COMPLETED"
+            ],
+            "example": "COMPLETED"
+          },
+          "retryCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "재시도 횟수",
+            "example": 2
+          },
+          "usedTipIds": {
+            "type": "array",
+            "description": "사용된 팁 ID 목록",
+            "example": [
+              1,
+              2,
+              3
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "comprehensionScore": {
+            "type": "integer",
+            "format": "int32",
+            "description": "이해도 점수 (0-100)",
+            "example": 85
+          },
+          "notes": {
+            "type": "string",
+            "description": "메모",
+            "example": "어려운 개념들이 많아서 시간이 오래 걸렸습니다."
+          }
+        }
+      },
+      "AccessibilitySettingsUpdateRequest": {
+        "type": "object",
+        "description": "접근성 설정 업데이트 요청 DTO",
+        "properties": {
+          "pageId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "페이지 ID",
+            "example": 1
+          },
+          "studentId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "학생 ID",
+            "example": 1
+          },
+          "documentId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "문서 ID",
+            "example": 1
+          },
+          "fontSize": {
+            "type": "integer",
+            "format": "int32",
+            "description": "글꼴 크기",
+            "example": 18
+          },
+          "lineSpacing": {
+            "type": "number",
+            "format": "float",
+            "description": "줄 간격",
+            "example": 1.5
+          },
+          "letterSpacing": {
+            "type": "number",
+            "format": "float",
+            "description": "글자 간격",
+            "example": 1.2
+          },
+          "colorScheme": {
+            "type": "string",
+            "description": "색상 스키마",
+            "enum": [
+              "LIGHT",
+              "DARK",
+              "SEPIA",
+              "CUSTOM"
+            ],
+            "example": "DARK_MODE"
+          },
+          "textToSpeechEnabled": {
+            "type": "boolean",
+            "description": "자동 음성 읽기 활성화",
+            "example": true
+          },
+          "readingHighlightEnabled": {
+            "type": "boolean",
+            "description": "읽기 강조 표시 활성화",
+            "example": true
+          },
+          "saveAsDefault": {
+            "type": "boolean",
+            "description": "기본 설정으로 저장",
+            "example": false
+          },
+          "applyToEntireDocument": {
+            "type": "boolean",
+            "description": "문서 전체에 적용",
+            "example": true
+          },
+          "customBackgroundColor": {
+            "type": "string",
+            "description": "사용자 정의 배경색",
+            "example": "#F5F5DC"
+          },
+          "customTextColor": {
+            "type": "string",
+            "description": "사용자 정의 글자색",
+            "example": "#333333"
+          }
+        }
+      },
+      "AIResponseDto": {
+        "type": "object",
+        "properties": {
+          "output": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "DocumentDto": {
+        "type": "object",
+        "description": "문서 정보 DTO",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "문서 ID",
+            "example": 1
+          },
+          "teacherId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "선생님 ID",
+            "example": 1
+          },
+          "title": {
+            "type": "string",
+            "description": "문서 제목",
+            "example": "생태계와 환경"
+          },
+          "originalFilename": {
+            "type": "string",
+            "description": "원본 파일명",
+            "example": "ecology_and_environment.pdf"
+          },
+          "fileSize": {
+            "type": "integer",
+            "format": "int64",
+            "description": "파일 크기(바이트)",
+            "example": 1024000
+          },
+          "pageCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "페이지 수",
+            "example": 10
+          },
+          "grade": {
+            "type": "string",
+            "description": "학년",
+            "enum": [
+              "GRADE_1",
+              "GRADE_2",
+              "GRADE_3",
+              "GRADE_4",
+              "GRADE_5",
+              "GRADE_6"
+            ],
+            "example": "GRADE_3"
+          },
+          "subjectPath": {
+            "type": "string",
+            "description": "과목 경로",
+            "example": "science/ecology"
+          },
+          "processStatus": {
+            "type": "string",
+            "description": "처리 상태",
+            "enum": [
+              "PENDING",
+              "PROCESSING",
+              "COMPLETED",
+              "FAILED"
+            ],
+            "example": "COMPLETED"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "생성 시간"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "수정 시간"
+          }
+        }
+      },
+      "DocumentResponseDto": {
+        "type": "object",
+        "description": "문서 업로드 응답 DTO",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "처리 성공 여부",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "응답 메시지",
+            "example": "PDF 업로드 완료. 비동기 처리가 시작되었습니다."
+          },
+          "document": {
+            "$ref": "#/components/schemas/DocumentDto",
+            "description": "문서 정보"
+          }
+        }
+      },
+      "DocumentProcessStatusDto": {
+        "type": "object",
+        "description": "문서 처리 상태 응답 DTO",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "처리 성공 여부",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "응답 메시지",
+            "example": "문서 처리 상태 조회 성공"
+          },
+          "documentId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "문서 ID",
+            "example": 1
+          },
+          "status": {
+            "type": "string",
+            "description": "처리 상태",
+            "enum": [
+              "PENDING",
+              "PROCESSING",
+              "COMPLETED",
+              "FAILED"
+            ],
+            "example": "PROCESSING"
+          },
+          "progress": {
+            "type": "integer",
+            "format": "int32",
+            "description": "처리 진행도 (0-100)",
+            "example": 65
+          }
+        }
+      },
+      "CourseReqDto": {
+        "type": "object",
+        "properties": {
+          "teacherId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "subjectPath": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "grade": {
+            "type": "string",
+            "enum": [
+              "GRADE_1",
+              "GRADE_2",
+              "GRADE_3",
+              "GRADE_4",
+              "GRADE_5",
+              "GRADE_6"
+            ]
+          },
+          "state": {
+            "type": "string"
+          }
+        }
+      },
+      "CourseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "teacherId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "subjectPath": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "grade": {
+            "type": "string",
+            "enum": [
+              "GRADE_1",
+              "GRADE_2",
+              "GRADE_3",
+              "GRADE_4",
+              "GRADE_5",
+              "GRADE_6"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "state": {
+            "type": "string"
+          }
+        }
+      },
+      "CourseInfoReqDto": {
+        "type": "object",
+        "properties": {
+          "courseId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "studentId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "teacherId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "learningTime": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPage": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "CourseInfoDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "courseId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "studentId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "teacherId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "learningTime": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPage": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "UserInfoDto": {
+        "type": "object",
+        "description": "사용자 정보 응답 DTO",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "사용자 닉네임",
+            "example": "홍길동"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "사용자 ID",
+            "example": 1
+          },
+          "clientId": {
+            "type": "string",
+            "description": "카카오 ID",
+            "example": 123456789
+          },
+          "userType": {
+            "type": "string",
+            "description": "사용자 타입",
+            "enum": [
+              "STUDENT",
+              "TEACHER",
+              "UNREGISTERED"
+            ],
+            "example": "STUDENT"
+          }
+        }
+      },
+      "TeacherDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "profileImageUrl": {
+            "type": "string"
+          }
+        }
+      },
+      "StudentDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "teacherId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "grade": {
+            "type": "string",
+            "enum": [
+              "GRADE_1",
+              "GRADE_2",
+              "GRADE_3",
+              "GRADE_4",
+              "GRADE_5",
+              "GRADE_6"
+            ]
+          },
+          "type": {
+            "type": "string"
+          },
+          "state": {
+            "type": "boolean"
+          },
+          "profileImageUrl": {
+            "type": "string"
+          },
+          "interests": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TeacherCodeDto": {
+        "type": "object",
+        "properties": {
+          "matchCode": {
+            "type": "string"
+          }
+        }
+      },
+      "StudentDocumentListResponseDto": {
+        "type": "object",
+        "description": "학생 문서 목록 응답 DTO",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "처리 성공 여부",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "응답 메시지",
+            "example": "할당된 문서 목록 조회 성공"
+          },
+          "documents": {
+            "type": "array",
+            "description": "문서 목록",
+            "items": {
+              "$ref": "#/components/schemas/DocumentDto"
+            }
+          }
+        }
+      },
+      "PageDto": {
+        "type": "object",
+        "description": "페이지 정보 DTO",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "페이지 ID",
+            "example": 1
+          },
+          "documentId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "문서 ID",
+            "example": 1
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32",
+            "description": "페이지 번호",
+            "example": 1
+          },
+          "sectionTitle": {
+            "type": "string",
+            "description": "섹션 제목",
+            "example": "생태계의 구성 요소"
+          },
+          "readingLevel": {
+            "type": "integer",
+            "format": "int32",
+            "description": "읽기 난이도 (1-10)",
+            "example": 5
+          },
+          "wordCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "단어 수",
+            "example": 250
+          },
+          "complexityScore": {
+            "type": "number",
+            "format": "float",
+            "description": "복잡도 점수 (0.0-1.0)",
+            "example": 0.6
+          },
+          "processingStatus": {
+            "type": "string",
+            "description": "처리 상태",
+            "enum": [
+              "PENDING",
+              "PROCESSING",
+              "COMPLETED",
+              "FAILED"
+            ],
+            "example": "COMPLETED"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "생성 시간"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "수정 시간"
+          }
+        }
+      },
+      "PageListResponseDto": {
+        "type": "object",
+        "description": "페이지 목록 응답 DTO",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "처리 성공 여부",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "응답 메시지",
+            "example": "페이지 목록 조회 성공"
+          },
+          "pages": {
+            "type": "array",
+            "description": "페이지 목록",
+            "items": {
+              "$ref": "#/components/schemas/PageDto"
+            }
+          }
+        }
+      },
+      "AuthResponseDto": {
+        "type": "object",
+        "properties": {
+          "registered": {
+            "type": "boolean"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "nickname": {
+            "type": "string"
+          },
+          "userType": {
+            "type": "string"
+          },
+          "accessToken": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          }
+        }
+      },
+      "Block": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "TEXT",
+              "HEADING1",
+              "HEADING2",
+              "HEADING3",
+              "LIST",
+              "DOTTED",
+              "IMAGE",
+              "TABLE",
+              "PAGE_TIP",
+              "PAGE_IMAGE"
+            ]
+          }
+        }
+      },
+      "JsonNode": {
+        "type": "object"
+      },
+      "PageContentResponse": {
+        "type": "object",
+        "description": "페이지 콘텐츠 응답",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "페이지 ID"
+          },
+          "documentId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "문서 ID"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32",
+            "description": "페이지 번호"
+          },
+          "originalContent": {
+            "type": "string",
+            "description": "원본 콘텐츠"
+          },
+          "processedContent": {
+            "$ref": "#/components/schemas/JsonNode",
+            "description": "처리된 콘텐츠 (JSON)"
+          },
+          "processingStatus": {
+            "type": "string",
+            "description": "처리 상태",
+            "enum": [
+              "PENDING",
+              "PROCESSING",
+              "COMPLETED",
+              "FAILED"
+            ],
+            "example": "COMPLETED"
+          },
+          "sectionTitle": {
+            "type": "string",
+            "description": "섹션 제목"
+          },
+          "readingLevel": {
+            "type": "integer",
+            "format": "int32",
+            "description": "읽기 레벨"
+          },
+          "wordCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "단어 수"
+          },
+          "complexityScore": {
+            "type": "number",
+            "format": "float",
+            "description": "복잡도 점수"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "생성 시간"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "수정 시간"
+          },
+          "blocks": {
+            "type": "array",
+            "description": "Block 구조화 데이터. type: HEADING1, TEXT, LIST, IMAGE, TABLE, PAGE_TIP, PAGE_IMAGE 등. 예시: [ {\"id\":\"1\",\"type\":\"HEADING1\",\"text\":\"챕터 제목\"}, {\"id\":\"2\",\"type\":\"TEXT\",\"text\":\"본문\"}, {\"id\":\"3\",\"type\":\"LIST\",\"items\":[\"항목1\",\"항목2\"]} ]",
+            "example": [
+              {
+                "id": "1",
+                "type": "HEADING1",
+                "text": "챕터 제목"
+              },
+              {
+                "id": "2",
+                "type": "TEXT",
+                "text": "본문"
+              },
+              {
+                "id": "3",
+                "type": "LIST",
+                "items": [
+                  "항목1",
+                  "항목2"
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Block"
+            }
+          }
+        }
+      },
+      "PageTipResponse": {
+        "type": "object",
+        "description": "페이지 팁 응답",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "팁 ID"
+          },
+          "pageId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "페이지 ID"
+          },
+          "term": {
+            "type": "string",
+            "description": "용어"
+          },
+          "simplifiedExplanation": {
+            "type": "string",
+            "description": "간소화된 설명"
+          },
+          "termPosition": {
+            "$ref": "#/components/schemas/JsonNode",
+            "description": "용어 위치 정보 (JSON)"
+          },
+          "termType": {
+            "type": "string",
+            "description": "용어 타입",
+            "enum": [
+              "DIFFICULT_WORD",
+              "COMPLEX_CONCEPT",
+              "ABSTRACT_IDEA",
+              "TECHNICAL_TERM"
+            ],
+            "example": "VOCABULARY"
+          },
+          "visualAidNeeded": {
+            "type": "boolean",
+            "description": "시각적 보조 필요 여부"
+          },
+          "readAloudText": {
+            "type": "string",
+            "description": "읽기 텍스트"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "생성 시간"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "수정 시간"
+          }
+        }
+      },
+      "PageImageResponse": {
+        "type": "object",
+        "description": "페이지 이미지 응답",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "description": "이미지 ID"
+          },
+          "pageId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "페이지 ID"
+          },
+          "imageUrl": {
+            "type": "string",
+            "description": "이미지 URL"
+          },
+          "imageType": {
+            "type": "string",
+            "description": "이미지 타입",
+            "enum": [
+              "CONCEPT_VISUALIZATION",
+              "DIAGRAM",
+              "COMPARISON_CHART",
+              "EXAMPLE_ILLUSTRATION"
+            ],
+            "example": "DIAGRAM"
+          },
+          "conceptReference": {
+            "type": "string",
+            "description": "개념 참조"
+          },
+          "altText": {
+            "type": "string",
+            "description": "대체 텍스트"
+          },
+          "positionInPage": {
+            "$ref": "#/components/schemas/JsonNode",
+            "description": "페이지 내 위치 정보 (JSON)"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "생성 시간"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "수정 시간"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  }
+}

--- a/src/features/viewer/lib/parse-blocks.tsx
+++ b/src/features/viewer/lib/parse-blocks.tsx
@@ -1,0 +1,170 @@
+import type { ReactNode } from 'react';
+import type { Block } from '../model/types';
+
+export function parseBlocks(
+	blocks: Block[],
+	options?: {
+		fontSize?: number;
+		fontFamily?: string;
+		lineSpacing?: number;
+		onSpeak?: (text: string) => void;
+	},
+): ReactNode[] {
+	if (!blocks) return [];
+	const {
+		fontSize = 16,
+		fontFamily = 'Noto Sans KR',
+		lineSpacing = 1.5,
+		onSpeak,
+	} = options || {};
+
+	return blocks.map((block, i) => {
+		const key = block.id ? String(block.id) : `${i}`;
+		switch (block.type) {
+			case 'TEXT':
+				return (
+					<p
+						key={key}
+						style={{ fontFamily, fontSize, lineHeight: lineSpacing }}
+					>
+						{block.text}
+					</p>
+				);
+			case 'HEADING1':
+				return (
+					<h2
+						key={key}
+						style={{
+							fontFamily,
+							fontSize: fontSize + 8,
+							lineHeight: lineSpacing,
+						}}
+						className="font-bold mb-2"
+					>
+						{block.text}
+					</h2>
+				);
+			case 'HEADING2':
+				return (
+					<h3
+						key={key}
+						style={{
+							fontFamily,
+							fontSize: fontSize + 4,
+							lineHeight: lineSpacing,
+						}}
+						className="font-bold mb-2"
+					>
+						{block.text}
+					</h3>
+				);
+			case 'HEADING3':
+				return (
+					<h4
+						key={key}
+						style={{
+							fontFamily,
+							fontSize: fontSize + 2,
+							lineHeight: lineSpacing,
+						}}
+						className="font-bold mb-2"
+					>
+						{block.text}
+					</h4>
+				);
+			case 'LIST':
+			case 'DOTTED':
+				return (
+					<ul
+						key={key}
+						className="list-disc pl-8 mb-4"
+						style={{ fontFamily, fontSize, lineHeight: lineSpacing }}
+					>
+						{block.items.map((item, idx) => (
+							<li
+								key={block.id ? `${block.id}-item-${idx}` : `${i}-item-${idx}`}
+								className="mb-1 group relative"
+							>
+								{item}
+								{onSpeak && (
+									<button
+										type="button"
+										onClick={() => onSpeak(item)}
+										className="ml-2 opacity-0 group-hover:opacity-100 transition-opacity inline-flex items-center"
+									>
+										<span role="img" aria-label="speak">
+											🔊
+										</span>
+									</button>
+								)}
+							</li>
+						))}
+					</ul>
+				);
+			case 'IMAGE':
+				return (
+					<figure key={key} className="mb-4">
+						<img
+							src={block.url}
+							alt={block.alt}
+							className="rounded-md max-w-full h-auto"
+							style={{ width: block.width, height: block.height }}
+						/>
+					</figure>
+				);
+			case 'TABLE':
+				return (
+					<div key={key} className="overflow-x-auto mb-4">
+						<table
+							className="min-w-full border text-sm"
+							style={{ fontFamily, fontSize, lineHeight: lineSpacing }}
+						>
+							<thead>
+								<tr>
+									{block.headers.map((header, idx) => (
+										<th
+											key={
+												block.id
+													? `${block.id}-header-${idx}`
+													: `${i}-header-${idx}`
+											}
+											className="border px-2 py-1 bg-gray-100"
+										>
+											{header}
+										</th>
+									))}
+								</tr>
+							</thead>
+							<tbody>
+								{block.rows.map((row, rowIdx) => (
+									<tr
+										key={
+											block.id
+												? `${block.id}-row-${rowIdx}`
+												: `${i}-row-${rowIdx}`
+										}
+									>
+										{row.map((cell, cellIdx) => (
+											<td
+												key={
+													block.id
+														? `${block.id}-cell-${rowIdx}-${cellIdx}`
+														: `${i}-cell-${rowIdx}-${cellIdx}`
+												}
+												className="border px-2 py-1"
+											>
+												{cell}
+											</td>
+										))}
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				);
+			// PAGE_TIP, PAGE_IMAGE는 뷰어에서 별도 처리
+			default:
+				return null;
+		}
+	});
+}

--- a/src/features/viewer/model/types.ts
+++ b/src/features/viewer/model/types.ts
@@ -1,3 +1,52 @@
+export type Block =
+  | {
+      id: string
+      type: 'TEXT'
+      text: string
+    }
+  | {
+      id: string
+      type: 'HEADING1' | 'HEADING2' | 'HEADING3'
+      text: string
+    }
+  | {
+      id: string
+      type: 'LIST' | 'DOTTED'
+      items: string[]
+    }
+  | {
+      id: string
+      type: 'IMAGE'
+      url: string
+      alt: string
+      width?: number
+      height?: number
+    }
+  | {
+      id: string
+      type: 'TABLE'
+      headers: string[]
+      rows: string[][]
+    }
+  | {
+      id: string
+      type: 'PAGE_TIP'
+      tipId: string
+    }
+  | {
+      id: string
+      type: 'PAGE_IMAGE'
+      imageId: string
+    }
+
+export interface PageBlockApiResponse {
+  pageId: string
+  title: string
+  blocks: Block[]
+  createdAt: string
+  updatedAt: string
+}
+
 export interface Document {
   id: number
   title: string
@@ -6,53 +55,12 @@ export interface Document {
   subjectPath?: string
 }
 
-export type ProcessedContentBlock =
-  | {
-      id?: string
-      type: 'heading'
-      level?: 1 | 2 | 3
-      text?: string
-      content?: string
-    }
-  | {
-      id?: string
-      type: 'paragraph'
-      text?: string
-      content?: string
-    }
-  | {
-      id?: string
-      type: 'image'
-      url?: string
-      src?: string
-      alt?: string
-      caption?: string
-    }
-  | {
-      id?: string
-      type: 'list'
-      ordered?: boolean
-      items: string[]
-    }
-  | {
-      id?: string
-      type: 'table'
-      headers?: string[]
-      rows?: string[][]
-    }
-  | {
-      id?: string
-      type: string
-      text?: string
-      content?: string
-    }
-
 export interface PageContentResponse {
   id: number
   documentId: number
   pageNumber: number
   originalContent: string
-  processedContent: { blocks: ProcessedContentBlock[] }
+  processedContent: Block[]
   processingStatus: 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED'
   sectionTitle: string
   readingLevel: number

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,2 +1,2 @@
-export * from './axios';
+export * from './utils';
 export * from './tanstack-query';


### PR DESCRIPTION
## PR 리뷰: feature/pdf

### 주요 변경 요약

- **Block 기반 문서 뷰어 구조 도입**
  - API 명세(document-block-api-guide)에 맞춰 Block 타입(HEADING1~3, TEXT, LIST, IMAGE, TABLE 등) 및 페이지 데이터 구조를 전면적으로 정비
  - 기존 ProcessedContentBlock 등 임시 타입 제거, Block 타입만 남기고 명확하게 분기

- **중앙 파서(parseBlocks) 리팩토링**
  - Block 타입별로 대문자 type(HEADING1, TEXT 등)로 분기
  - 각 타입별 필드만 사용해 JSX 반환, 불필요한 타입 분기/필드 제거
  - 추상화 및 재사용성 강화

- **문서 뷰어 페이지 리팩토링**
  - API 응답 구조에 맞게 pageContent의 processedContent(Block[])를 파싱하여 parseBlocks로 렌더링
  - sectionTitle, blocks 등도 명세에 맞게 사용
  - 팁/이미지 등 부가 정보도 id 기준으로 쿼리

- **타입/모델 일관성 확보**
  - 실제 API 응답 구조와 FE 타입, 파서, 뷰어가 완전히 일치하도록 정비
  - Block 타입, PageContentResponse 등 모든 모델을 명세와 동기화

### 테스트/QA 포인트

- 다양한 Block 조합(HEADING, TEXT, LIST, IMAGE, TABLE 등)에서 정상 렌더링 확인
- API 응답 구조가 바뀌었을 때 타입 에러/파싱 에러가 없는지 확인
- 페이지 이동, 폰트/줄간격 등 뷰어 옵션 정상 동작
- 팁/이미지 등 부가 정보 연동 정상 동작

# 참고해주세요!
현재 문서 파싱을 제외하고 다른 데이터는 아직 난독증 환자를 위한 요구사항으로 더 맞춰나가야합니다!